### PR TITLE
fixed read_group types to not include 'null' and fixed req'd links fo…

### DIFF
--- a/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
@@ -26,24 +26,27 @@ systemProperties:
   - error_type
 
 links:
-  - name: projects
-    backref: aggregated_somatic_mutations
-    label: derived_from
-    target_type: project
-    multiplicity: many_to_one
-    required: false
-  - name: somatic_aggregation_workflows
-    backref: aggregated_somatic_mutations
-    label: data_from
-    target_type: somatic_aggregation_workflow
-    multiplicity: one_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: aggregated_somatic_mutations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: projects
+      backref: aggregated_somatic_mutations
+      label: derived_from
+      target_type: project
+      multiplicity: many_to_one
+      required: false
+    - name: somatic_aggregation_workflows
+      backref: aggregated_somatic_mutations
+      label: data_from
+      target_type: somatic_aggregation_workflow
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: aggregated_somatic_mutations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
@@ -37,7 +37,7 @@ links:
     label: data_from
     target_type: somatic_aggregation_workflow
     multiplicity: one_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: aggregated_somatic_mutations
     label: data_from
@@ -55,7 +55,6 @@ required:
   - data_format
   - data_type
   - experimental_strategy
-  - somatic_aggregation_workflows
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/aggregated_somatic_mutation.yaml
@@ -57,7 +57,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/aligned_reads.yaml
+++ b/gdcdictionary/schemas/aligned_reads.yaml
@@ -75,8 +75,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/aligned_reads.yaml
+++ b/gdcdictionary/schemas/aligned_reads.yaml
@@ -25,42 +25,45 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
-    subgroup:
-      - name: alignment_cocleaning_workflows
+    - exclusive: false
+      required: true
+      subgroup:
+      - name: core_metadata_collections
         backref: aligned_reads_files
         label: data_from
-        target_type: alignment_cocleaning_workflow
+        target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
-      - name: alignment_workflows
-        backref: aligned_reads_files
-        label: data_from
-        target_type: alignment_workflow
-        multiplicity: many_to_one
+      - exclusive: true
         required: false
-  - exclusive: true
-    required: false
-    subgroup:
-      - name: submitted_unaligned_reads_files
-        backref: aligned_reads_files
-        label: matched_to
-        target_type: submitted_unaligned_reads
-        multiplicity: one_to_many
+        subgroup:
+        - name: alignment_cocleaning_workflows
+          backref: aligned_reads_files
+          label: data_from
+          target_type: alignment_cocleaning_workflow
+          multiplicity: many_to_one
+          required: false
+        - name: alignment_workflows
+          backref: aligned_reads_files
+          label: data_from
+          target_type: alignment_workflow
+          multiplicity: many_to_one
+          required: false
+      - exclusive: true
         required: false
-      - name: submitted_aligned_reads_files
-        backref: aligned_reads_files
-        label: matched_to
-        target_type: submitted_aligned_reads
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: aligned_reads_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+        subgroup:
+        - name: submitted_unaligned_reads_files
+          backref: aligned_reads_files
+          label: matched_to
+          target_type: submitted_unaligned_reads
+          multiplicity: one_to_many
+          required: false
+        - name: submitted_aligned_reads_files
+          backref: aligned_reads_files
+          label: matched_to
+          target_type: submitted_aligned_reads
+          multiplicity: one_to_one
+          required: false
 
 
 required:

--- a/gdcdictionary/schemas/aligned_reads.yaml
+++ b/gdcdictionary/schemas/aligned_reads.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: alignment_cocleaning_workflows
         backref: aligned_reads_files

--- a/gdcdictionary/schemas/aligned_reads_index.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: submitted_aligned_reads_files
         backref: aligned_reads_indexes

--- a/gdcdictionary/schemas/aligned_reads_index.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: submitted_aligned_reads_files
-        backref: aligned_reads_indexes
-        label: derived_from
-        target_type: submitted_aligned_reads
-        multiplicity: one_to_one
-        required: false
-      - name: aligned_reads_files
-        backref: aligned_reads_indexes
-        label: derived_from
-        target_type: aligned_reads
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: aligned_reads_indexes
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - name: core_metadata_collections
+      backref: aligned_reads_indexes
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: submitted_aligned_reads_files
+          backref: aligned_reads_indexes
+          label: derived_from
+          target_type: submitted_aligned_reads
+          multiplicity: one_to_one
+          required: false
+        - name: aligned_reads_files
+          backref: aligned_reads_indexes
+          label: derived_from
+          target_type: aligned_reads
+          multiplicity: one_to_one
+          required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/alignment_cocleaning_workflow.yaml
+++ b/gdcdictionary/schemas/alignment_cocleaning_workflow.yaml
@@ -43,8 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/alignment_workflow.yaml
+++ b/gdcdictionary/schemas/alignment_workflow.yaml
@@ -43,8 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/aliquot.yaml
+++ b/gdcdictionary/schemas/aliquot.yaml
@@ -39,12 +39,6 @@ links:
         target_type: sample
         multiplicity: many_to_many
         required: false
-  # - name: centers
-  #   backref: aliquots
-  #   label: shipped_to
-  #   target_type: center
-  #   multiplicity: many_to_one
-  #   required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/analysis_metadata.yaml
+++ b/gdcdictionary/schemas/analysis_metadata.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: submitted_aligned_reads_files
         backref: analysis_metadata_files

--- a/gdcdictionary/schemas/analysis_metadata.yaml
+++ b/gdcdictionary/schemas/analysis_metadata.yaml
@@ -25,9 +25,12 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
+    - exclusive: true
+      required: false
+      subgroup:
       - name: submitted_aligned_reads_files
         backref: analysis_metadata_files
         label: derived_from
@@ -40,12 +43,12 @@ links:
         target_type: file
         multiplicity: one_to_many
         required: false
-  - name: core_metadata_collections
-    backref: analysis_metadata_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - name: core_metadata_collections
+      backref: analysis_metadata_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/analyte.yaml
+++ b/gdcdictionary/schemas/analyte.yaml
@@ -43,7 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - analyte_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/annotated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/annotated_somatic_mutation.yaml
@@ -25,9 +25,12 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
+    - exclusive: true
+      required: false
+      subgroup:
       - name: somatic_annotation_workflows
         backref: annotated_somatic_mutations
         label: data_from
@@ -40,12 +43,12 @@ links:
         target_type: genomic_profile_harmonization_workflow
         multiplicity: one_to_one
         required: false
-  - name: core_metadata_collections
-    backref: annotated_somatic_mutations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - name: core_metadata_collections
+      backref: annotated_somatic_mutations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/annotated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/annotated_somatic_mutation.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: somatic_annotation_workflows
         backref: annotated_somatic_mutations

--- a/gdcdictionary/schemas/annotated_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/annotated_somatic_mutation.yaml
@@ -59,7 +59,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/annotation.yaml
+++ b/gdcdictionary/schemas/annotation.yaml
@@ -88,12 +88,6 @@ links:
         target_type: case
         multiplicity: many_to_many
         required: false
-      # - name: centers
-      #   backref: annotations
-      #   label: annotates
-      #   target_type: center
-      #   multiplicity: many_to_many
-      #   required: false
       - name: clinical_supplements
         backref: annotations
         label: annotates
@@ -352,12 +346,6 @@ links:
         target_type: submitted_unaligned_reads
         multiplicity: many_to_many
         required: false
-      # - name: tissue_source_sites
-      #   backref: annotations
-      #   label: annotates
-      #   target_type: tissue_source_site
-      #   multiplicity: many_to_many
-      #   required: false
       - name: treatments
         backref: annotations
         label: annotates
@@ -368,7 +356,6 @@ links:
 required:
   - submitter_id
   - type
-  - category
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/archive.yaml
+++ b/gdcdictionary/schemas/archive.yaml
@@ -55,13 +55,9 @@ required:
   - file_name
   - file_size
   - md5sum
-  - state
-  - revision
-  - projects
   - data_category
   - data_format
   - data_type
-
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/archive.yaml
+++ b/gdcdictionary/schemas/archive.yaml
@@ -27,24 +27,27 @@ systemProperties:
   - error_type
 
 links:
-  - name: projects
-    backref: archives
-    label: member_of
-    target_type: project
-    multiplicity: many_to_one
+  - exclusive: false
     required: true
-  - name: related_to_files
-    backref: related_archives
-    label: related_to
-    target_type: file
-    multiplicity: one_to_many
-    required: false
-  - name: core_metadata_collections
-    backref: archives
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    subgroup:
+    - name: projects
+      backref: archives
+      label: member_of
+      target_type: project
+      multiplicity: many_to_one
+      required: false
+    - name: related_to_files
+      backref: related_archives
+      label: related_to
+      target_type: file
+      multiplicity: one_to_many
+      required: false
+    - name: core_metadata_collections
+      backref: archives
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/biospecimen_supplement.yaml
+++ b/gdcdictionary/schemas/biospecimen_supplement.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: case
     multiplicity: many_to_many
-    required: true
+    required: false
   - name: archives
     backref: biospecimen_supplements
     label: member_of

--- a/gdcdictionary/schemas/biospecimen_supplement.yaml
+++ b/gdcdictionary/schemas/biospecimen_supplement.yaml
@@ -25,24 +25,27 @@ systemProperties:
   - error_type
 
 links:
-  - name: cases
-    backref: biospecimen_supplements
-    label: derived_from
-    target_type: case
-    multiplicity: many_to_many
-    required: false
-  - name: archives
-    backref: biospecimen_supplements
-    label: member_of
-    target_type: archive
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: biospecimen_supplements
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: cases
+      backref: biospecimen_supplements
+      label: derived_from
+      target_type: case
+      multiplicity: many_to_many
+      required: false
+    - name: archives
+      backref: biospecimen_supplements
+      label: member_of
+      target_type: archive
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: biospecimen_supplements
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -30,18 +30,11 @@ links:
     target_type: project
     multiplicity: many_to_one
     required: true
-  # - name: tissue_source_sites
-  #   backref: cases
-  #   label: processed_at
-  #   target_type: tissue_source_site
-  #   multiplicity: many_to_one
-  #   required: false
 
 required:
   - submitter_id
   - type
-  - disease_type
-  - primary_site
+  - projects
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/clinical.yaml
+++ b/gdcdictionary/schemas/clinical.yaml
@@ -31,7 +31,6 @@ links:
     required: true
 
 required:
-  - id
   - submitter_id
   - type
   - cases

--- a/gdcdictionary/schemas/clinical_supplement.yaml
+++ b/gdcdictionary/schemas/clinical_supplement.yaml
@@ -25,24 +25,27 @@ systemProperties:
   - error_type
 
 links:
-  - name: cases
-    backref: clinical_supplements
-    label: derived_from
-    target_type: case
-    multiplicity: many_to_many
-    required: false
-  - name: archives
-    backref: clinical_supplements
-    label: member_of
-    target_type: archive
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: clinical_supplements
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: cases
+      backref: clinical_supplements
+      label: derived_from
+      target_type: case
+      multiplicity: many_to_many
+      required: false
+    - name: archives
+      backref: clinical_supplements
+      label: member_of
+      target_type: archive
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: clinical_supplements
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/clinical_supplement.yaml
+++ b/gdcdictionary/schemas/clinical_supplement.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: case
     multiplicity: many_to_many
-    required: true
+    required: false
   - name: archives
     backref: clinical_supplements
     label: member_of

--- a/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
+++ b/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
@@ -51,8 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
+++ b/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: somatic_copy_number_workflow
     multiplicity: one_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: copy_number_auxiliary_files
     label: data_from

--- a/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
+++ b/gdcdictionary/schemas/copy_number_auxiliary_file.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: somatic_copy_number_workflows
-    backref: copy_number_auxiliary_files
-    label: derived_from
-    target_type: somatic_copy_number_workflow
-    multiplicity: one_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: copy_number_auxiliary_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: somatic_copy_number_workflows
+      backref: copy_number_auxiliary_files
+      label: derived_from
+      target_type: somatic_copy_number_workflow
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: copy_number_auxiliary_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/copy_number_estimate.yaml
+++ b/gdcdictionary/schemas/copy_number_estimate.yaml
@@ -27,7 +27,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: copy_number_variation_workflows
         backref: copy_number_estimates

--- a/gdcdictionary/schemas/copy_number_estimate.yaml
+++ b/gdcdictionary/schemas/copy_number_estimate.yaml
@@ -67,8 +67,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/copy_number_estimate.yaml
+++ b/gdcdictionary/schemas/copy_number_estimate.yaml
@@ -26,33 +26,36 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: copy_number_variation_workflows
-        backref: copy_number_estimates
-        label: derived_from
-        target_type: copy_number_variation_workflow
-        multiplicity: one_to_one
-        required: false
-      - name: genomic_profile_harmonization_workflows
-        backref: copy_number_estimates
-        label: derived_from
-        target_type: genomic_profile_harmonization_workflow
-        multiplicity: one_to_one
-        required: false
-      - name: somatic_copy_number_workflows
-        backref: copy_number_estimates
-        label: derived_from
-        target_type: somatic_copy_number_workflow
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: copy_number_estimates
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: copy_number_variation_workflows
+          backref: copy_number_estimates
+          label: derived_from
+          target_type: copy_number_variation_workflow
+          multiplicity: one_to_one
+          required: false
+        - name: genomic_profile_harmonization_workflows
+          backref: copy_number_estimates
+          label: derived_from
+          target_type: genomic_profile_harmonization_workflow
+          multiplicity: one_to_one
+          required: false
+        - name: somatic_copy_number_workflows
+          backref: copy_number_estimates
+          label: derived_from
+          target_type: somatic_copy_number_workflow
+          multiplicity: one_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: copy_number_estimates
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/copy_number_liftover_workflow.yaml
+++ b/gdcdictionary/schemas/copy_number_liftover_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - submitted_tangent_copy_numbers
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/copy_number_segment.yaml
+++ b/gdcdictionary/schemas/copy_number_segment.yaml
@@ -67,8 +67,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/copy_number_segment.yaml
+++ b/gdcdictionary/schemas/copy_number_segment.yaml
@@ -27,7 +27,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: copy_number_liftover_workflows
         backref: copy_number_segments

--- a/gdcdictionary/schemas/copy_number_segment.yaml
+++ b/gdcdictionary/schemas/copy_number_segment.yaml
@@ -26,33 +26,36 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: copy_number_liftover_workflows
-        backref: copy_number_segments
-        label: derived_from
-        target_type: copy_number_liftover_workflow
-        multiplicity: one_to_one
-        required: false
-      - name: genomic_profile_harmonization_workflows
-        backref: copy_number_segments
-        label: derived_from
-        target_type: genomic_profile_harmonization_workflow
-        multiplicity: one_to_one
-        required: false
-      - name: somatic_copy_number_workflows
-        backref: copy_number_segments
-        label: derived_from
-        target_type: somatic_copy_number_workflow
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: copy_number_segments
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: copy_number_liftover_workflows
+          backref: copy_number_segments
+          label: derived_from
+          target_type: copy_number_liftover_workflow
+          multiplicity: one_to_one
+          required: false
+        - name: genomic_profile_harmonization_workflows
+          backref: copy_number_segments
+          label: derived_from
+          target_type: genomic_profile_harmonization_workflow
+          multiplicity: one_to_one
+          required: false
+        - name: somatic_copy_number_workflows
+          backref: copy_number_segments
+          label: derived_from
+          target_type: somatic_copy_number_workflow
+          multiplicity: one_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: copy_number_segments
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/copy_number_variation_workflow.yaml
+++ b/gdcdictionary/schemas/copy_number_variation_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - copy_number_segments
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -53,11 +53,9 @@ properties:
 
   age_at_index:
     $ref: "_terms.yaml#/age_at_index/common"
-    oneOf:
-      - type: integer
-        maximum: 89
-        minimum: 0
-      - type: "null"
+    type: integer
+    maximum: 89
+    minimum: 0
 
   age_is_obfuscated:
     $ref: "_terms.yaml#/age_is_obfuscated/common"
@@ -1721,10 +1719,9 @@ properties:
 
   year_of_birth:
     $ref: "_terms.yaml#/year_of_birth/common"
-    oneOf:
-      - type: integer
-        minimum: 1900
-      - type: "null"
+    type: integer
+    minimum: 1900
+
 
   year_of_death:
     $ref: "_terms.yaml#/year_of_death/common"

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -34,18 +34,12 @@ links:
 required:
   - submitter_id
   - type
-  - ethnicity
-  - gender
-  - race
-  - vital_status
+  - cases
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
 
-deprecated:
-  - premature_at_birth
-  - weeks_gestation_at_birth
 
 properties:
 

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -75,11 +75,9 @@ properties:
 
   age_at_diagnosis:
     $ref: "_terms.yaml#/age_at_diagnosis/common"
-    oneOf:
-      - type: integer
-        maximum: 32872
-        minimum: 0
-      - type: "null"
+    type: integer
+    maximum: 32872
+    minimum: 0
 
   ajcc_clinical_m:
     $ref: "_terms.yaml#/ajcc_clinical_m/common"
@@ -1298,33 +1296,25 @@ properties:
 
   days_to_last_follow_up:
     $ref: "_terms.yaml#/days_to_last_follow_up/common"
-    oneOf:
-      - type: number
-        maximum: 32872
-        minimum: -32872
-      - type: "null"
+    type: number
+    maximum: 32872
+    minimum: -32872
 
   days_to_last_known_disease_status:
     $ref: "_terms.yaml#/days_to_last_known_disease_status/common"
-    oneOf:
-      - type: number
-        maximum: 32872
-        minimum: -32872
-      - type: "null"
+    type: number
+    maximum: 32872
+    minimum: -32872
 
   days_to_recurrence:
     $ref: "_terms.yaml#/days_to_recurrence/common"
-    oneOf:
-      - type: number
-        maximum: 32872
-        minimum: -32872
-      - type: "null"
+    type: number
+    maximum: 32872
+    minimum: -32872
 
   diagnosis_is_primary_disease:
     $ref: "_terms.yaml#/diagnosis_is_primary_disease/common"
-    oneOf:
-      - type: boolean
-      - type: "null"
+    type: boolean
 
   double_expressor_lymphoma:
     $ref: "_terms.yaml#/double_expressor_lymphoma/common"
@@ -15568,11 +15558,10 @@ properties:
 
   year_of_diagnosis:
     $ref: "_terms.yaml#/year_of_diagnosis/common"
-    oneOf:
-      - type: integer
-        maximum: 2050
-        minimum: 1900
-      - type: "null"
+    type: integer
+    maximum: 2050
+    minimum: 1900
+
 
   cases:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -35,22 +35,11 @@ links:
 required:
   - submitter_id
   - type
-  - morphology
-  - primary_diagnosis
-  - site_of_resection_or_biopsy
-  - tissue_or_organ_of_origin
+  - cases
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
-
-deprecated:
-  - metastasis_at_diagnosis_site
-  - micropapillary_features
-  - mitotic_count
-  - papillary_renal_cell_type
-  - pregnant_at_diagnosis
-  - primary_disease
 
 properties:
 

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -35,10 +35,8 @@ links:
 required:
   - submitter_id
   - type
-  - age_at_diagnosis
   - morphology
   - primary_diagnosis
-  - diagnosis_is_primary_disease
   - site_of_resection_or_biopsy
   - tissue_or_organ_of_origin
 

--- a/gdcdictionary/schemas/experiment_metadata.yaml
+++ b/gdcdictionary/schemas/experiment_metadata.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: read_groups
-        backref: experiment_metadata_files
-        label: derived_from
-        target_type: read_group
-        multiplicity: many_to_one
-        required: false
-      - name: files
-        backref: experiment_metadata_files
-        label: derived_from
-        target_type: file
-        multiplicity: one_to_many
-        required: false
-  - name: core_metadata_collections
-    backref: experiment_metadata_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: read_groups
+          backref: experiment_metadata_files
+          label: derived_from
+          target_type: read_group
+          multiplicity: many_to_one
+          required: false
+        - name: files
+          backref: experiment_metadata_files
+          label: derived_from
+          target_type: file
+          multiplicity: one_to_many
+          required: false
+    - name: core_metadata_collections
+      backref: experiment_metadata_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/experiment_metadata.yaml
+++ b/gdcdictionary/schemas/experiment_metadata.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: read_groups
         backref: experiment_metadata_files

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -33,18 +33,11 @@ links:
 required:
   - submitter_id
   - type
+  - cases
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
-
-deprecated:
-  - smokeless_tobacco_quit_age
-  - asbestos_exposure
-  - radon_exposure
-  - respirable_crystalline_silica_exposure
-  - years_smoked
-  - coal_dust_exposure
 
 properties:
 

--- a/gdcdictionary/schemas/expression_analysis_workflow.yaml
+++ b/gdcdictionary/schemas/expression_analysis_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - gene_expressions
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/family_history.yaml
+++ b/gdcdictionary/schemas/family_history.yaml
@@ -33,6 +33,7 @@ links:
 required:
   - submitter_id
   - type
+  - cases
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/file.yaml
+++ b/gdcdictionary/schemas/file.yaml
@@ -77,15 +77,12 @@ links:
         multiplicity: many_to_one
         required: false
 
-
-
 required:
   - submitter_id
   - type
   - file_name
   - file_size
   - md5sum
-  - state
   - data_category
   - data_format
   - data_type

--- a/gdcdictionary/schemas/file.yaml
+++ b/gdcdictionary/schemas/file.yaml
@@ -25,15 +25,15 @@ systemProperties:
   - error_type
 
 links:
-  - name: core_metadata_collections
-    backref: files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
   - exclusive: false
     required: true
     subgroup:
+      - name: core_metadata_collections
+        backref: files
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
       - name: aliquots
         backref: files
         label: data_from
@@ -52,13 +52,6 @@ links:
         target_type: case
         multiplicity: many_to_many
         required: false
-      # Gen3 does not support links to self
-      # - name: derived_files
-      #   backref: source_files
-      #   label: data_from
-      #   target_type: file
-      #   multiplicity: many_to_many
-      #   required: false
       - name: portions
         backref: files
         label: data_from
@@ -77,62 +70,13 @@ links:
         target_type: slide
         multiplicity: many_to_many
         required: false
-      # Gen3 does not support links to self
-      # - name: related_files
-      #   backref: parent_files
-      #   label: related_to
-      #   target_type: file
-      #   multiplicity: many_to_many
-      #   required: false
       - name: archives
         backref: files
         label: member_of
         target_type: archive
         multiplicity: many_to_one
         required: false
-      # Gen3 does not support duplicate links
-      # - name: described_cases
-      #   backref: describing_files
-      #   label: describes
-      #   target_type: case
-      #   multiplicity: many_to_one
-      #   required: false
-  # - name: tags
-  #   backref: files
-  #   label: memeber_of
-  #   target_type: tag
-  #   multiplicity: many_to_many
-  #   required: false
-  # - name: data_subtypes
-  #   backref: files
-  #   label: member_of
-  #   target_type: data_subtype
-  #   multiplicity: many_to_one
-  #   required: false
-  # - name: data_formats
-  #   backref: files
-  #   label: member_of
-  #   target_type: data_format
-  #   multiplicity: many_to_one
-  #   required: false
-  # - name: experimental_strategies
-  #   backref: files
-  #   label: member_of
-  #   target_type: experimental_strategy
-  #   multiplicity: many_to_one
-  #   required: false
-  # - name: centers
-  #   backref: files
-  #   label: submitted_by
-  #   target_type: center
-  #   multiplicity: many_to_one
-  #   required: false
-  # - name: platforms
-  #   backref: files
-  #   label: generated_from
-  #   target_type: platform
-  #   multiplicity: many_to_one
-  #   required: false
+
 
 
 required:

--- a/gdcdictionary/schemas/filtered_copy_number_segment.yaml
+++ b/gdcdictionary/schemas/filtered_copy_number_segment.yaml
@@ -25,19 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: copy_number_liftover_workflows
-    backref: filtered_copy_number_segments
-    label: data_from
-    target_type: copy_number_liftover_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: filtered_copy_number_segments
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
-
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: copy_number_liftover_workflows
+      backref: filtered_copy_number_segments
+      label: data_from
+      target_type: copy_number_liftover_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: filtered_copy_number_segments
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/filtered_copy_number_segment.yaml
+++ b/gdcdictionary/schemas/filtered_copy_number_segment.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: copy_number_liftover_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: filtered_copy_number_segments
     label: data_from

--- a/gdcdictionary/schemas/filtered_copy_number_segment.yaml
+++ b/gdcdictionary/schemas/filtered_copy_number_segment.yaml
@@ -50,7 +50,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/follow_up.yaml
+++ b/gdcdictionary/schemas/follow_up.yaml
@@ -45,7 +45,6 @@ links:
 required:
   - submitter_id
   - type
-  - days_to_follow_up
   - cases
 
 uniqueKeys:

--- a/gdcdictionary/schemas/follow_up.yaml
+++ b/gdcdictionary/schemas/follow_up.yaml
@@ -1414,11 +1414,9 @@ properties:
 
   days_to_follow_up:
     $ref: "_terms.yaml#/days_to_follow_up/common"
-    oneOf:
-      - type: integer
-        maximum: 32872
-        minimum: -32872
-      - type: "null"
+    type: integer
+    maximum: 32872
+    minimum: -32872
 
   days_to_imaging:
     $ref: "_terms.yaml#/days_to_imaging/common"

--- a/gdcdictionary/schemas/gene_expression.yaml
+++ b/gdcdictionary/schemas/gene_expression.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: rna_expression_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: gene_expressionsw
     label: data_from

--- a/gdcdictionary/schemas/gene_expression.yaml
+++ b/gdcdictionary/schemas/gene_expression.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: rna_expression_workflows
-    backref: gene_expressions
-    label: data_from
-    target_type: rna_expression_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: gene_expressionsw
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: rna_expression_workflows
+      backref: gene_expressions
+      label: data_from
+      target_type: rna_expression_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: gene_expressionsw
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/gene_expression.yaml
+++ b/gdcdictionary/schemas/gene_expression.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/genomic_profile_harmonization_workflow.yaml
+++ b/gdcdictionary/schemas/genomic_profile_harmonization_workflow.yaml
@@ -33,8 +33,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - submitted_genomic_profiles
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/germline_mutation_calling_workflow.yaml
+++ b/gdcdictionary/schemas/germline_mutation_calling_workflow.yaml
@@ -43,8 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/germline_mutation_index.yaml
+++ b/gdcdictionary/schemas/germline_mutation_index.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: simple_germline_variation
     multiplicity: one_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: germline_mutation_indexes
     label: data_from

--- a/gdcdictionary/schemas/germline_mutation_index.yaml
+++ b/gdcdictionary/schemas/germline_mutation_index.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: simple_germline_variations
-    backref: germline_mutation_indexes
-    label: derived_from
-    target_type: simple_germline_variation
-    multiplicity: one_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: germline_mutation_indexes
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: simple_germline_variations
+      backref: germline_mutation_indexes
+      label: derived_from
+      target_type: simple_germline_variation
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: germline_mutation_indexes
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/masked_methylation_array.yaml
+++ b/gdcdictionary/schemas/masked_methylation_array.yaml
@@ -26,18 +26,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: methylation_array_harmonization_workflows
-    backref: masked_methylation_arrays
-    label: data_from
-    target_type: methylation_array_harmonization_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: masked_methylation_arrays
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: methylation_array_harmonization_workflows
+      backref: masked_methylation_arrays
+      label: data_from
+      target_type: methylation_array_harmonization_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: masked_methylation_arrays
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/masked_methylation_array.yaml
+++ b/gdcdictionary/schemas/masked_methylation_array.yaml
@@ -52,9 +52,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
-  - channel
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/masked_methylation_array.yaml
+++ b/gdcdictionary/schemas/masked_methylation_array.yaml
@@ -31,7 +31,7 @@ links:
     label: data_from
     target_type: methylation_array_harmonization_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: masked_methylation_arrays
     label: data_from

--- a/gdcdictionary/schemas/masked_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/masked_somatic_mutation.yaml
@@ -39,7 +39,7 @@ links:
     multiplicity: many_to_one
     required: false
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: genomic_profile_harmonization_workflows
         backref: masked_somatic_mutations

--- a/gdcdictionary/schemas/masked_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/masked_somatic_mutation.yaml
@@ -26,33 +26,36 @@ systemProperties:
   - error_type
 
 links:
-  - name: core_metadata_collections
-    backref: masked_somatic_mutations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
-  - name: projects
-    backref: masked_somatic_mutations
-    label: derived_from
-    target_type: project
-    multiplicity: many_to_one
-    required: false
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: genomic_profile_harmonization_workflows
-        backref: masked_somatic_mutations
-        label: data_from
-        target_type: genomic_profile_harmonization_workflow
-        multiplicity: many_to_many
-        required: false
-      - name: somatic_aggregation_workflows
-        backref: masked_somatic_mutations
-        label: data_from
-        target_type: somatic_aggregation_workflow
-        multiplicity: one_to_one
-        required: false
+    - name: core_metadata_collections
+      backref: masked_somatic_mutations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
+    - name: projects
+      backref: masked_somatic_mutations
+      label: derived_from
+      target_type: project
+      multiplicity: many_to_one
+      required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: genomic_profile_harmonization_workflows
+          backref: masked_somatic_mutations
+          label: data_from
+          target_type: genomic_profile_harmonization_workflow
+          multiplicity: many_to_many
+          required: false
+        - name: somatic_aggregation_workflows
+          backref: masked_somatic_mutations
+          label: data_from
+          target_type: somatic_aggregation_workflow
+          multiplicity: one_to_one
+          required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/masked_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/masked_somatic_mutation.yaml
@@ -66,7 +66,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/methylation_array_harmonization_workflow.yaml
+++ b/gdcdictionary/schemas/methylation_array_harmonization_workflow.yaml
@@ -33,8 +33,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - raw_methylation_arrays
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/methylation_beta_value.yaml
@@ -32,7 +32,7 @@ links:
     multiplicity: many_to_one
     required: false
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: methylation_array_harmonization_workflows
         backref: methylation_beta_values

--- a/gdcdictionary/schemas/methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/methylation_beta_value.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - name: core_metadata_collections
-    backref: methylation_beta_values
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: methylation_array_harmonization_workflows
-        backref: methylation_beta_values
-        label: data_from
-        target_type: methylation_array_harmonization_workflow
-        multiplicity: many_to_one
-        required: false
-      - name: methylation_liftover_workflows
-        backref: methylation_beta_values
-        label: data_from
-        target_type: methylation_liftover_workflow
-        multiplicity: one_to_one
-        required: false
+    - name: core_metadata_collections
+      backref: methylation_beta_values
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: methylation_array_harmonization_workflows
+          backref: methylation_beta_values
+          label: data_from
+          target_type: methylation_array_harmonization_workflow
+          multiplicity: many_to_one
+          required: false
+        - name: methylation_liftover_workflows
+          backref: methylation_beta_values
+          label: data_from
+          target_type: methylation_liftover_workflow
+          multiplicity: one_to_one
+          required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/methylation_beta_value.yaml
@@ -59,8 +59,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/methylation_liftover_workflow.yaml
+++ b/gdcdictionary/schemas/methylation_liftover_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - submitted_methylation_beta_values
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/mirna_expression.yaml
+++ b/gdcdictionary/schemas/mirna_expression.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: mirna_expression_workflows
-    backref: mirna_expressions
-    label: data_from
-    target_type: mirna_expression_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: mirna_expressions
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: mirna_expression_workflows
+      backref: mirna_expressions
+      label: data_from
+      target_type: mirna_expression_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: mirna_expressions
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id

--- a/gdcdictionary/schemas/mirna_expression.yaml
+++ b/gdcdictionary/schemas/mirna_expression.yaml
@@ -50,7 +50,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/mirna_expression.yaml
+++ b/gdcdictionary/schemas/mirna_expression.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: mirna_expression_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: mirna_expressions
     label: data_from

--- a/gdcdictionary/schemas/mirna_expression_workflow.yaml
+++ b/gdcdictionary/schemas/mirna_expression_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - aligned_reads_files
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -49,9 +49,6 @@ links:
 required:
   - submitter_id
   - type
-  - gene_symbol
-  - molecular_analysis_method
-  - test_result
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/pathology_detail.yaml
+++ b/gdcdictionary/schemas/pathology_detail.yaml
@@ -34,16 +34,11 @@ links:
 required:
   - submitter_id
   - type
+  - diagnoses
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
-
-deprecated:
-  - epithelioid_cell_percent
-  - extrascleral_extension
-  - size_extraocular_nodule
-  - spindle_cell_percent
 
 properties:
 

--- a/gdcdictionary/schemas/pathology_report.yaml
+++ b/gdcdictionary/schemas/pathology_report.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: sample
     multiplicity: one_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: pathology_reports
     label: data_from

--- a/gdcdictionary/schemas/pathology_report.yaml
+++ b/gdcdictionary/schemas/pathology_report.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: samples
-    backref: pathology_reports
-    label: derived_from
-    target_type: sample
-    multiplicity: one_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: pathology_reports
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: samples
+      backref: pathology_reports
+      label: derived_from
+      target_type: sample
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: pathology_reports
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/portion.yaml
+++ b/gdcdictionary/schemas/portion.yaml
@@ -29,12 +29,6 @@ links:
     target_type: sample
     multiplicity: many_to_one
     required: true
-  # - name: centers
-  #   backref: portions
-  #   label: shipped_to
-  #   target_type: center
-  #   multiplicity: many_to_one
-  #   required: false
 
 required:
   - submitter_id
@@ -69,6 +63,3 @@ properties:
 
   samples:
     $ref: "_definitions.yaml#/to_one"
-
-  # centers:
-  #   $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: portions
         backref: protein_expressions

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: portions
-        backref: protein_expressions
-        label: derived_from
-        target_type: portion
-        multiplicity: one_to_one
-        required: false
-      - name: samples
-        backref: protein_expressions
-        label: derived_from
-        target_type: sample
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: protein_expressions
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: portions
+          backref: protein_expressions
+          label: derived_from
+          target_type: portion
+          multiplicity: one_to_one
+          required: false
+        - name: samples
+          backref: protein_expressions
+          label: derived_from
+          target_type: sample
+          multiplicity: one_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: protein_expressions
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -60,8 +60,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/publication.yaml
+++ b/gdcdictionary/schemas/publication.yaml
@@ -32,23 +32,21 @@ links:
 required:
   - submitter_id
   - type
-  - pmid
-  - doi
   - files
 
 uniqueKeys:
   - [id]
-  - [pmid]
-  - [doi]
 
 properties:
 
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   pmid:
+    description: "PubMed is an index of the biomedical literature. A PMID, also known as the PubMed reference number, is a number assigned by the NIH National Library of Medicine to papers indexed in PubMed."
     type: string
 
   doi:
+    description: "A DOI, or Digital Object Identifier, is a unique alphanumeric string assigned to a document that provides a permanent link to its location on the internet."
     type: string
 
   files:

--- a/gdcdictionary/schemas/raw_methylation_array.yaml
+++ b/gdcdictionary/schemas/raw_methylation_array.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: raw_methylation_arrays
-    label: data_from
-    target_type: aliquot
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: raw_methylation_arrays
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: aliquots
+      backref: raw_methylation_arrays
+      label: data_from
+      target_type: aliquot
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: raw_methylation_arrays
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/raw_methylation_array.yaml
+++ b/gdcdictionary/schemas/raw_methylation_array.yaml
@@ -51,9 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
-  - channel
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/raw_methylation_array.yaml
+++ b/gdcdictionary/schemas/raw_methylation_array.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: aliquot
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: raw_methylation_arrays
     label: data_from

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -34,26 +34,10 @@ required:
   - submitter_id
   - type
   - aliquots
-  - experiment_name
-  - sequencing_center
-  - platform
-  - library_selection
-  - library_strategy
-  - library_name
-  - read_group_name
-  - target_capture_kit
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
-
-deprecated:
-  - RIN
-  - target_capture_kit_catalog_number
-  - target_capture_kit_name
-  - target_capture_kit_target_region
-  - target_capture_kit_vendor
-  - target_capture_kit_version
 
 properties:
 

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -40,8 +40,6 @@ required:
   - library_selection
   - library_strategy
   - library_name
-  - is_paired_end
-  - read_length
   - read_group_name
   - target_capture_kit
 

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -182,9 +182,7 @@ properties:
 
   is_paired_end:
     $ref: "_terms.yaml#/is_paired_end/common"
-    oneOf:
-      - type: boolean
-      - type: "null"
+    type: boolean
 
   lane_number:
     $ref: "_terms.yaml#/lane_number/common"
@@ -293,10 +291,8 @@ properties:
 
   read_length:
     $ref: "_terms.yaml#/read_length/common"
-    oneOf:
-      - type: integer
-        minimum: 0
-      - type: "null"
+    type: integer
+    minimum: 0
 
   rin:
     $ref: "_terms.yaml#/rin/common"

--- a/gdcdictionary/schemas/read_group_qc.yaml
+++ b/gdcdictionary/schemas/read_group_qc.yaml
@@ -23,9 +23,12 @@ systemProperties:
   - state
 
 links:
-  - exclusive: true
+  - exclusive: false
     required: true
     subgroup:
+    - exclusive: true
+      required: false
+      subgroup:
       - name: submitted_aligned_reads_files
         backref: read_group_qcs
         label: data_from
@@ -38,17 +41,16 @@ links:
         target_type: submitted_unaligned_reads
         multiplicity: one_to_many
         required: false
-  - name: read_groups
-    backref: read_group_qcs
-    label: generated_from
-    target_type: read_group
-    multiplicity: many_to_one
-    required: true
+    - name: read_groups
+      backref: read_group_qcs
+      label: generated_from
+      target_type: read_group
+      multiplicity: many_to_one
+      required: false
 
 required:
   - submitter_id
   - type
-  - workflow_link
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/rna_expression_workflow.yaml
+++ b/gdcdictionary/schemas/rna_expression_workflow.yaml
@@ -55,8 +55,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/run_metadata.yaml
+++ b/gdcdictionary/schemas/run_metadata.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: read_groups
-        backref: run_metadata_files
-        label: derived_from
-        target_type: read_group
-        multiplicity: many_to_one
-        required: false
-      - name: files
-        backref: run_metadata_files
-        label: derived_from
-        target_type: file
-        multiplicity: one_to_many
-        required: false
-  - name: core_metadata_collections
-    backref: run_metadata_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: read_groups
+          backref: run_metadata_files
+          label: derived_from
+          target_type: read_group
+          multiplicity: many_to_one
+          required: false
+        - name: files
+          backref: run_metadata_files
+          label: derived_from
+          target_type: file
+          multiplicity: one_to_many
+          required: false
+    - name: core_metadata_collections
+      backref: run_metadata_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/run_metadata.yaml
+++ b/gdcdictionary/schemas/run_metadata.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: read_groups
         backref: run_metadata_files

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -33,33 +33,18 @@ links:
     target_type: case
     multiplicity: many_to_one
     required: true
-  # - name: tissue_source_sites
-  #   backref: samples
-  #   label: processed_at
-  #   target_type: tissue_source_site
-  #   multiplicity: one_to_one
-  #   required: false
   - name: diagnoses
     backref: samples
     label: related_to
     target_type: diagnosis
     multiplicity: many_to_one
     required: false
-  # Gen3 doesn't support references to self
-  # - name: parent_samples 
-  #   backref: child_samples
-  #   label: derived_from
-  #   target_type: sample
-  #   multiplicity: many_to_one
-  #   required: false
+
 
 required:
   - submitter_id
   - type
-  - preservation_method
-  - specimen_type
-  - tissue_type
-  - tumor_descriptor
+  - cases
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/secondary_expression_analysis.yaml
+++ b/gdcdictionary/schemas/secondary_expression_analysis.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: expression_analysis_workflows
-    backref: secondary_expression_analyses
-    label: data_from
-    target_type: expression_analysis_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: secondary_expression_analyses
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: expression_analysis_workflows
+      backref: secondary_expression_analyses
+      label: data_from
+      target_type: expression_analysis_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: secondary_expression_analyses
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/secondary_expression_analysis.yaml
+++ b/gdcdictionary/schemas/secondary_expression_analysis.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/secondary_expression_analysis.yaml
+++ b/gdcdictionary/schemas/secondary_expression_analysis.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: expression_analysis_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: secondary_expression_analyses
     label: data_from

--- a/gdcdictionary/schemas/simple_germline_variation.yaml
+++ b/gdcdictionary/schemas/simple_germline_variation.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: germline_mutation_calling_workflows
-    backref: simple_germline_variations
-    label: data_from
-    target_type: germline_mutation_calling_workflow
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: simple_germline_variations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: germline_mutation_calling_workflows
+      backref: simple_germline_variations
+      label: data_from
+      target_type: germline_mutation_calling_workflow
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: simple_germline_variations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/simple_germline_variation.yaml
+++ b/gdcdictionary/schemas/simple_germline_variation.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/simple_germline_variation.yaml
+++ b/gdcdictionary/schemas/simple_germline_variation.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: germline_mutation_calling_workflow
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: simple_germline_variations
     label: data_from

--- a/gdcdictionary/schemas/simple_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/simple_somatic_mutation.yaml
@@ -27,7 +27,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: somatic_mutation_calling_workflows
         backref: simple_somatic_mutations

--- a/gdcdictionary/schemas/simple_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/simple_somatic_mutation.yaml
@@ -32,18 +32,18 @@ links:
     - exclusive: true
       required: false
       subgroup:
-        - name: somatic_mutation_calling_workflows
-          backref: simple_somatic_mutations
-          label: data_from
-          target_type: somatic_mutation_calling_workflow
-          multiplicity: many_to_one
-          required: false
-        - name: genomic_profile_harmonization_workflows
-          backref: simple_somatic_mutations
-          label: data_from
-          target_type: genomic_profile_harmonization_workflow
-          multiplicity: one_to_one
-          required: false
+      - name: somatic_mutation_calling_workflows
+        backref: simple_somatic_mutations
+        label: data_from
+        target_type: somatic_mutation_calling_workflow
+        multiplicity: many_to_one
+        required: false
+      - name: genomic_profile_harmonization_workflows
+        backref: simple_somatic_mutations
+        label: data_from
+        target_type: genomic_profile_harmonization_workflow
+        multiplicity: one_to_one
+        required: false
     - name: core_metadata_collections
       backref: simple_somatic_mutations
       label: data_from
@@ -61,7 +61,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/simple_somatic_mutation.yaml
+++ b/gdcdictionary/schemas/simple_somatic_mutation.yaml
@@ -26,27 +26,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: somatic_mutation_calling_workflows
-        backref: simple_somatic_mutations
-        label: data_from
-        target_type: somatic_mutation_calling_workflow
-        multiplicity: many_to_one
-        required: false
-      - name: genomic_profile_harmonization_workflows
-        backref: simple_somatic_mutations
-        label: data_from
-        target_type: genomic_profile_harmonization_workflow
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: simple_somatic_mutations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: somatic_mutation_calling_workflows
+          backref: simple_somatic_mutations
+          label: data_from
+          target_type: somatic_mutation_calling_workflow
+          multiplicity: many_to_one
+          required: false
+        - name: genomic_profile_harmonization_workflows
+          backref: simple_somatic_mutations
+          label: data_from
+          target_type: genomic_profile_harmonization_workflow
+          multiplicity: one_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: simple_somatic_mutations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/slide.yaml
+++ b/gdcdictionary/schemas/slide.yaml
@@ -43,7 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - section_location
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/slide_image.yaml
+++ b/gdcdictionary/schemas/slide_image.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/slide_image.yaml
+++ b/gdcdictionary/schemas/slide_image.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: slides
-    backref: slide_images
-    label: data_from
-    target_type: slide
-    multiplicity: many_to_many
-    required: false
-  - name: core_metadata_collections
-    backref: slide_images
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: slides
+      backref: slide_images
+      label: data_from
+      target_type: slide
+      multiplicity: many_to_many
+      required: false
+    - name: core_metadata_collections
+      backref: slide_images
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/slide_image.yaml
+++ b/gdcdictionary/schemas/slide_image.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: slide
     multiplicity: many_to_many
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: slide_images
     label: data_from

--- a/gdcdictionary/schemas/somatic_aggregation_workflow.yaml
+++ b/gdcdictionary/schemas/somatic_aggregation_workflow.yaml
@@ -43,8 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/somatic_annotation_workflow.yaml
+++ b/gdcdictionary/schemas/somatic_annotation_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - simple_somatic_mutations
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/somatic_copy_number_workflow.yaml
+++ b/gdcdictionary/schemas/somatic_copy_number_workflow.yaml
@@ -43,8 +43,6 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/somatic_mutation_calling_workflow.yaml
+++ b/gdcdictionary/schemas/somatic_mutation_calling_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - aligned_reads_files
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/somatic_mutation_index.yaml
+++ b/gdcdictionary/schemas/somatic_mutation_index.yaml
@@ -31,24 +31,24 @@ links:
     - exclusive: true
       required: false
       subgroup:
-        - name: simple_somatic_mutations
-          backref: somatic_mutation_indexes
-          label: derived_from
-          target_type: simple_somatic_mutation
-          multiplicity: one_to_one
-          required: false
-        - name: annotated_somatic_mutations
-          backref: somatic_mutation_indexes
-          label: derived_from
-          target_type: annotated_somatic_mutation
-          multiplicity: one_to_one
-          required: false
-        - name: structural_variations
-          backref: somatic_mutation_indexes
-          label: derived_from
-          target_type: structural_variation
-          multiplicity: one_to_one
-          required: false
+      - name: simple_somatic_mutations
+        backref: somatic_mutation_indexes
+        label: derived_from
+        target_type: simple_somatic_mutation
+        multiplicity: one_to_one
+        required: false
+      - name: annotated_somatic_mutations
+        backref: somatic_mutation_indexes
+        label: derived_from
+        target_type: annotated_somatic_mutation
+        multiplicity: one_to_one
+        required: false
+      - name: structural_variations
+        backref: somatic_mutation_indexes
+        label: derived_from
+        target_type: structural_variation
+        multiplicity: one_to_one
+        required: false
     - name: core_metadata_collections
       backref: somatic_mutation_indexes
       label: data_from

--- a/gdcdictionary/schemas/somatic_mutation_index.yaml
+++ b/gdcdictionary/schemas/somatic_mutation_index.yaml
@@ -25,33 +25,36 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: simple_somatic_mutations
-        backref: somatic_mutation_indexes
-        label: derived_from
-        target_type: simple_somatic_mutation
-        multiplicity: one_to_one
-        required: false
-      - name: annotated_somatic_mutations
-        backref: somatic_mutation_indexes
-        label: derived_from
-        target_type: annotated_somatic_mutation
-        multiplicity: one_to_one
-        required: false
-      - name: structural_variations
-        backref: somatic_mutation_indexes
-        label: derived_from
-        target_type: structural_variation
-        multiplicity: one_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: somatic_mutation_indexes
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: simple_somatic_mutations
+          backref: somatic_mutation_indexes
+          label: derived_from
+          target_type: simple_somatic_mutation
+          multiplicity: one_to_one
+          required: false
+        - name: annotated_somatic_mutations
+          backref: somatic_mutation_indexes
+          label: derived_from
+          target_type: annotated_somatic_mutation
+          multiplicity: one_to_one
+          required: false
+        - name: structural_variations
+          backref: somatic_mutation_indexes
+          label: derived_from
+          target_type: structural_variation
+          multiplicity: one_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: somatic_mutation_indexes
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/somatic_mutation_index.yaml
+++ b/gdcdictionary/schemas/somatic_mutation_index.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: simple_somatic_mutations
         backref: somatic_mutation_indexes

--- a/gdcdictionary/schemas/structural_variant_calling_workflow.yaml
+++ b/gdcdictionary/schemas/structural_variant_calling_workflow.yaml
@@ -34,8 +34,7 @@ links:
 required:
   - submitter_id
   - type
-  - workflow_link
-  - workflow_type
+  - aligned_reads_files
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/structural_variation.yaml
+++ b/gdcdictionary/schemas/structural_variation.yaml
@@ -25,27 +25,30 @@ systemProperties:
   - error_type
 
 links:
-  - exclusive: true
-    required: false
+  - exclusive: false
+    required: true
     subgroup:
-      - name: genomic_profile_harmonization_workflows
-        backref: structural_variations
-        label: data_from
-        target_type: genomic_profile_harmonization_workflow
-        multiplicity: one_to_one
-        required: false
-      - name: structural_variant_calling_workflows
-        backref: structural_variations
-        label: data_from
-        target_type: structural_variant_calling_workflow
-        multiplicity: many_to_one
-        required: false
-  - name: core_metadata_collections
-    backref: structural_variations
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+    - exclusive: true
+      required: false
+      subgroup:
+        - name: genomic_profile_harmonization_workflows
+          backref: structural_variations
+          label: data_from
+          target_type: genomic_profile_harmonization_workflow
+          multiplicity: one_to_one
+          required: false
+        - name: structural_variant_calling_workflows
+          backref: structural_variations
+          label: data_from
+          target_type: structural_variant_calling_workflow
+          multiplicity: many_to_one
+          required: false
+    - name: core_metadata_collections
+      backref: structural_variations
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/structural_variation.yaml
+++ b/gdcdictionary/schemas/structural_variation.yaml
@@ -31,18 +31,18 @@ links:
     - exclusive: true
       required: false
       subgroup:
-        - name: genomic_profile_harmonization_workflows
-          backref: structural_variations
-          label: data_from
-          target_type: genomic_profile_harmonization_workflow
-          multiplicity: one_to_one
-          required: false
-        - name: structural_variant_calling_workflows
-          backref: structural_variations
-          label: data_from
-          target_type: structural_variant_calling_workflow
-          multiplicity: many_to_one
-          required: false
+      - name: genomic_profile_harmonization_workflows
+        backref: structural_variations
+        label: data_from
+        target_type: genomic_profile_harmonization_workflow
+        multiplicity: one_to_one
+        required: false
+      - name: structural_variant_calling_workflows
+        backref: structural_variations
+        label: data_from
+        target_type: structural_variant_calling_workflow
+        multiplicity: many_to_one
+        required: false
     - name: core_metadata_collections
       backref: structural_variations
       label: data_from

--- a/gdcdictionary/schemas/structural_variation.yaml
+++ b/gdcdictionary/schemas/structural_variation.yaml
@@ -26,7 +26,7 @@ systemProperties:
 
 links:
   - exclusive: true
-    required: true
+    required: false
     subgroup:
       - name: genomic_profile_harmonization_workflows
         backref: structural_variations

--- a/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: read_group
     multiplicity: one_to_many
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_aligned_reads_files
     label: data_from

--- a/gdcdictionary/schemas/submitted_aligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_aligned_reads.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_aligned_reads_files
-    label: data_from
-    target_type: read_group
-    multiplicity: one_to_many
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_aligned_reads_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: read_groups
+      backref: submitted_aligned_reads_files
+      label: data_from
+      target_type: read_group
+      multiplicity: one_to_many
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_aligned_reads_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_expression_array.yaml
+++ b/gdcdictionary/schemas/submitted_expression_array.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: aliquot
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_expression_arrays
     label: data_from

--- a/gdcdictionary/schemas/submitted_expression_array.yaml
+++ b/gdcdictionary/schemas/submitted_expression_array.yaml
@@ -51,8 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_expression_array.yaml
+++ b/gdcdictionary/schemas/submitted_expression_array.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: submitted_expression_arrays
-    label: derived_from
-    target_type: aliquot
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_expression_arrays
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: aliquots
+      backref: submitted_expression_arrays
+      label: derived_from
+      target_type: aliquot
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_expression_arrays
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_genomic_profile.yaml
+++ b/gdcdictionary/schemas/submitted_genomic_profile.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_genomic_profiles
-    label: data_from
-    target_type: read_group
-    multiplicity: many_to_many
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_genomic_profiles
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: read_groups
+      backref: submitted_genomic_profiles
+      label: data_from
+      target_type: read_group
+      multiplicity: many_to_many
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_genomic_profiles
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_genomic_profile.yaml
+++ b/gdcdictionary/schemas/submitted_genomic_profile.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_genomic_profile.yaml
+++ b/gdcdictionary/schemas/submitted_genomic_profile.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: read_group
     multiplicity: many_to_many
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_genomic_profiles
     label: data_from
@@ -49,7 +49,6 @@ required:
   - data_format
   - data_type
   - experimental_strategy
-  - read_groups
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_genotyping_array.yaml
+++ b/gdcdictionary/schemas/submitted_genotyping_array.yaml
@@ -51,8 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - platform
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_genotyping_array.yaml
+++ b/gdcdictionary/schemas/submitted_genotyping_array.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: aliquot
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_genotyping_arrays
     label: data_from

--- a/gdcdictionary/schemas/submitted_genotyping_array.yaml
+++ b/gdcdictionary/schemas/submitted_genotyping_array.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: submitted_genotyping_arrays
-    label: derived_from
-    target_type: aliquot
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_genotyping_arrays
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: aliquots
+      backref: submitted_genotyping_arrays
+      label: derived_from
+      target_type: aliquot
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_genotyping_arrays
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: submitted_methylation_beta_values
-    label: derived_from
-    target_type: aliquot
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_methylation_beta_values
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: aliquots
+      backref: submitted_methylation_beta_values
+      label: derived_from
+      target_type: aliquot
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_methylation_beta_values
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
+++ b/gdcdictionary/schemas/submitted_methylation_beta_value.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: aliquot
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_methylation_beta_values
     label: data_from

--- a/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
+++ b/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: aliquots
-    backref: submitted_tangent_copy_number
-    label: derived_from
-    target_type: aliquot
-    multiplicity: one_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_tangent_copy_number
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: aliquots
+      backref: submitted_tangent_copy_number
+      label: derived_from
+      target_type: aliquot
+      multiplicity: one_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_tangent_copy_number
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
+++ b/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
@@ -51,7 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
+++ b/gdcdictionary/schemas/submitted_tangent_copy_number.yaml
@@ -30,7 +30,7 @@ links:
     label: derived_from
     target_type: aliquot
     multiplicity: one_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_tangent_copy_number
     label: data_from

--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -25,18 +25,21 @@ systemProperties:
   - error_type
 
 links:
-  - name: read_groups
-    backref: submitted_unaligned_reads_files
-    label: data_from
-    target_type: read_group
-    multiplicity: many_to_one
-    required: false
-  - name: core_metadata_collections
-    backref: submitted_unaligned_reads_files
-    label: data_from
-    target_type: core_metadata_collection
-    multiplicity: many_to_one
-    required: false
+  - exclusive: false
+    required: true
+    subgroup:
+    - name: read_groups
+      backref: submitted_unaligned_reads_files
+      label: data_from
+      target_type: read_group
+      multiplicity: many_to_one
+      required: false
+    - name: core_metadata_collections
+      backref: submitted_unaligned_reads_files
+      label: data_from
+      target_type: core_metadata_collection
+      multiplicity: many_to_one
+      required: false
 
 
 required:

--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -51,8 +51,6 @@ required:
   - data_category
   - data_format
   - data_type
-  - experimental_strategy
-  - read_pair_number
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/submitted_unaligned_reads.yaml
+++ b/gdcdictionary/schemas/submitted_unaligned_reads.yaml
@@ -30,7 +30,7 @@ links:
     label: data_from
     target_type: read_group
     multiplicity: many_to_one
-    required: true
+    required: false
   - name: core_metadata_collections
     backref: submitted_unaligned_reads_files
     label: data_from

--- a/gdcdictionary/schemas/treatment.yaml
+++ b/gdcdictionary/schemas/treatment.yaml
@@ -34,16 +34,11 @@ links:
 required:
   - submitter_id
   - type
+  - diagnoses
 
 uniqueKeys:
   - [id]
   - [project_id, submitter_id]
-
-deprecated:
-  - days_to_treatment
-  - treatment_anatomic_site
-  - treatment_arm
-  - therapeutic_level_achieved
 
 properties:
 


### PR DESCRIPTION
fixed read_group types to not include 'null' and fixed req'd links for files. Specifically, for file nodes, no links should be required so that core_metadata_collection can be used to create data lakes in projects (files linking only to CMC/project).
