### PR TITLE
Set CGS risk criteria link to one-to-one

### DIFF
--- a/gdcdictionary/schemas/cgs_risk_key_criteria.yaml
+++ b/gdcdictionary/schemas/cgs_risk_key_criteria.yaml
@@ -28,7 +28,7 @@ links:
     backref: cgs_risk_key_criteria
     label: describes
     target_type: case
-    multiplicity: many_to_many
+    multiplicity: one_to_one
     required: true
 
 required:


### PR DESCRIPTION
- fixed cgs risk key criteria link multiplicity (many_to_many -> one_to_one)